### PR TITLE
Fix inconsistent spelling of color

### DIFF
--- a/src/pages/classes/case-classes.md
+++ b/src/pages/classes/case-classes.md
@@ -140,13 +140,13 @@ In Scala 2.10 and earlier we can define case classes containing 0 to 22 fields. 
 
 #### Case Cats
 
-Recall that a `Cat` has a `String` colour and food. Define a case class to represent a `Cat`.
+Recall that a `Cat` has a `String` color and food. Define a case class to represent a `Cat`.
 
 <div class="solution">
 Another simple finger exercise.
 
 ```tut:book:silent
-case class Cat(colour: String, food: String)
+case class Cat(color: String, food: String)
 ```
 </div>
 

--- a/src/pages/classes/classes.md
+++ b/src/pages/classes/classes.md
@@ -226,7 +226,7 @@ We now have enough machinery to have some fun playing with classes.
 Recall the cats from a previous exercise:
 
 +-----------+-----------------+-------+
-| Name      | Colour          | Food  |
+| Name      | Color          | Food  |
 +===========+=================+=======+
 | Oswald    | Black           | Milk  |
 +-----------+-----------------+-------+
@@ -242,7 +242,7 @@ Define a class `Cat` and then create an object for each cat in the table above.
 This is a finger exercise to get you used to the syntax of defining classes.
 
 ```tut:book:silent
-class Cat(val colour: String, val food: String)
+class Cat(val color: String, val food: String)
 
 val oswald = new Cat("Black", "Milk")
 val henderson = new Cat("Ginger", "Chips")

--- a/src/pages/classes/pattern-matching.md
+++ b/src/pages/classes/pattern-matching.md
@@ -113,7 +113,7 @@ Define an object `ChipShop` with a method `willServe`. This method should accept
 We can start by writing the skeleton suggested by the problem text.
 
 ```tut:book:silent
-case class Cat(name: String, colour: String, food: String)
+case class Cat(name: String, color: String, food: String)
 ```
 
 ```scala

--- a/src/pages/collections/map-and-set.md
+++ b/src/pages/collections/map-and-set.md
@@ -308,7 +308,7 @@ val favoriteLolcats = Map(
 
 Use the code as test data for the following exercises:
 
-Write a method `favoriteColor` that accepts a person's name as a parameter and returns their favorite colour.
+Write a method `favoriteColor` that accepts a person's name as a parameter and returns their favorite color.
 
 <div class="solution">
 The person may or may not be a key in the `favoriteColors` map so the function should return an `Option` result:

--- a/src/pages/intro/object-literals.md
+++ b/src/pages/intro/object-literals.md
@@ -232,10 +232,10 @@ We have also seen the difference between methods and fields---fields refer to va
 
 #### Cat-o-matique
 
-The table below shows the names, colour, and favourite foods of three cats. Define an object for each cat. (For experienced programmers: we haven't covered classes yet.)
+The table below shows the names, color, and favourite foods of three cats. Define an object for each cat. (For experienced programmers: we haven't covered classes yet.)
 
 +-----------+-----------------+-------+
-| Name      | Colour          | Food  |
+| Name      | Color          | Food  |
 +===========+=================+=======+
 | Oswald    | Black           | Milk  |
 +-----------+-----------------+-------+
@@ -251,17 +251,17 @@ This is just a finger exercise to get you used to the syntax of defining objects
 
 ```tut:book:silent
 object Oswald {
-  val colour: String = "Black"
+  val color: String = "Black"
   val food: String = "Milk"
 }
 
 object Henderson {
-  val colour: String = "Ginger"
+  val color: String = "Ginger"
   val food: String = "Chips"
 }
 
 object Quentin {
-  val colour: String = "Tabby and white"
+  val color: String = "Tabby and white"
   val food: String = "Curry"
 }
 ```

--- a/src/pages/traits/modelling-data-with-traits.md
+++ b/src/pages/traits/modelling-data-with-traits.md
@@ -6,7 +6,7 @@ Our goal in this section is to see how to translate a data model into Scala code
 
 ### The Product Type Pattern
 
-Our first pattern is to model data that contains other data. We might describe this as "`A` *has a* `B` *and* `C`". For example, a `Cat` has a colour and a favourite food; a `Visitor` has an id and a creation date; and so on.
+Our first pattern is to model data that contains other data. We might describe this as "`A` *has a* `B` *and* `C`". For example, a `Cat` has a color and a favourite food; a `Visitor` has an id and a creation date; and so on.
 
 The way we write this is to use a case class. We've already done this many times in exercises; now we're formalising the pattern.
 

--- a/src/pages/traits/sealed-traits.md
+++ b/src/pages/traits/sealed-traits.md
@@ -168,7 +168,7 @@ sealed trait Color {
   def green: Double
   def blue: Double
 
-  // We decided to define a "light" colour as one with
+  // We decided to define a "light" color as one with
   // an average RGB of more than 0.5:
   def isLight = (red + green + blue) / 3.0 > 0.5
   def isDark = !isLight
@@ -263,7 +263,7 @@ object Draw {
 Write a sealed trait `Color` to make our shapes more interesting.
 
  - give `Color` three properties for its RGB values;
- - create three predefined colours: `Red`, `Yellow`, and `Pink`;
+ - create three predefined colors: `Red`, `Yellow`, and `Pink`;
  - provide a means for people to produce their own custom `Colors`
    with their own RGB values;
  - provide a means for people to tell whether any `Color` is
@@ -271,22 +271,22 @@ Write a sealed trait `Color` to make our shapes more interesting.
 
 A lot of this exercise is left deliberately open to interpretation. The important thing is to practice working with traits, classes, and objects.
 
-Decisions such as how to model colours and what is considered a light or dark colour can either be left up to you or discussed with other class members.
+Decisions such as how to model colors and what is considered a light or dark color can either be left up to you or discussed with other class members.
 
-Edit the code for `Shape` and its subtypes to add a colour to each shape.
+Edit the code for `Shape` and its subtypes to add a color to each shape.
 
-Finally, update the code for `Draw.apply` to print the colour of the argument as well as its shape and dimensions:
+Finally, update the code for `Draw.apply` to print the color of the argument as well as its shape and dimensions:
 
- - if the argument is a predefined colour, print that colour by name:
+ - if the argument is a predefined color, print that color by name:
 
 ```tut:book
 Draw(Circle(10, Yellow))
 ```
 
- - if the argument is a custom colour rather than a predefined one,
+ - if the argument is a custom color rather than a predefined one,
    print the word "light" or "dark" instead.
 
-You may want to deal with the colour in a helper method.
+You may want to deal with the color in a helper method.
 
 <div class="solution">
 One solution to this exercise is presented below. Remember that a lot of the implementation details are unimportant---the crucial aspects of a correct solution are:
@@ -296,13 +296,13 @@ One solution to this exercise is presented below. Remember that a lot of the imp
     - The trait should contains the `isLight` method,
       defined in terms of the RGB values.
 
- - There must be three objects representing the predefined colours:
+ - There must be three objects representing the predefined colors:
     - Each object must `extend Color`.
     - Each object should override the RGB values as `vals`.
     - Marking the objects as `final` is optional.
     - Making the objects `case objects` is also optional.
 
- - There must be a class representing custom colours:
+ - There must be a class representing custom colors:
     - The class must `extend Color`.
     - Marking the class `final` is optional.
     - Making the class a `case class` is optional (although highly recommended).
@@ -326,7 +326,7 @@ sealed trait Color {
   def green: Double
   def blue: Double
 
-  // We decided to define a "light" colour as one with
+  // We decided to define a "light" color as one with
   // an average RGB of more than 0.5:
   def isLight = (red + green + blue) / 3.0 > 0.5
   def isDark = !isLight

--- a/src/pages/traits/traits.md
+++ b/src/pages/traits/traits.md
@@ -162,7 +162,7 @@ case class Name(...) extends TraitName {
 
 Demand for Cat Simulator 1.0 is exploding! For v2 we're going to go beyond the domestic cat to model `Tiger`s, `Lion`s, and `Panther`s in addition to the `Cat`. Define a trait `Feline` and then define all the different species as subtypes of `Feline`. To make things interesting, define:
 
-- on `Feline` a `colour` as before;
+- on `Feline` a `color` as before;
 - on `Feline` a `String` `sound`, which for a cat is `"meow"` and is `"roar"` for all other felines;
 - only `Cat` has a favourite food; and
 - `Lion`s have an `Int` `maneSize`.
@@ -172,23 +172,23 @@ This is mostly a finger exercise to get you used to trait syntax but there are a
 
 ```tut:book:silent
 trait Feline {
-  def colour: String
+  def color: String
   def sound: String
 }
 
-case class Lion(colour: String, maneSize: Int) extends Feline {
+case class Lion(color: String, maneSize: Int) extends Feline {
   val sound = "roar"
 }
 
-case class Tiger(colour: String) extends Feline {
+case class Tiger(color: String) extends Feline {
   val sound = "roar"
 }
 
-case class Panther(colour: String) extends Feline {
+case class Panther(color: String) extends Feline {
   val sound = "roar"
 }
 
-case class Cat(colour: String, food: String) extends Feline {
+case class Cat(color: String, food: String) extends Feline {
   val sound = "meow"
 }
 ```
@@ -197,7 +197,7 @@ Notice that `sound` is not defined as a constructor argument. Since it is a cons
 
 ```tut:book:silent
 trait Feline {
-  def colour: String
+  def color: String
   def sound: String = "roar"
 }
 ```


### PR DESCRIPTION
Color is currently spelt using a mixture of the US and UK spellings in the book. By standardising it to the US spelling (same as CSS/Java/etc.) broken code and confusion can be reduced.