### PR TITLE
fix `directorsAge` bug and request `newer` method

### DIFF
--- a/src/pages/classes/companion-objects.md
+++ b/src/pages/classes/companion-objects.md
@@ -109,6 +109,7 @@ Write companion objects for `Director` and `Film` as follows:
  - the `Film` companion object should contain:
     - an `apply` method that accepts the same parameters as the constructor of the class
       and returns a new `Film`;
+    - a method `newer` that accepts two `Films` and returns the most recently-released `Film`;
     - a method `highestRating` that accepts two `Films` and returns the highest
       `imdbRating` of the two;
     - a method `oldestDirectorAtTheTime` that accepts two `Films` and returns the `Director`
@@ -149,7 +150,7 @@ class Film(
   val director: Director) {
 
   def directorsAge =
-    director.yearOfBirth - yearOfRelease
+    yearOfRelease - director.yearOfBirth
 
   def isDirectedBy(director: Director) =
     this.director == director


### PR DESCRIPTION
PR just fixes a couple of bugs in the 'Extended body of work' exercise

BUG1: The model solution defined the `directorsAge` to be yearOfBirth - yearOfRelease; so was negative for all valid director/film pairs

BUG2: The method `newer` was defined in the model `Film` object but the reader was not asked to implement this method.

Both bugs are fixed