### PR TITLE
fix bug in solution 4.3: use def not val in trait

### DIFF
--- a/src/pages/traits/traits.md
+++ b/src/pages/traits/traits.md
@@ -282,8 +282,8 @@ sealed trait Rectangular extends Shape {
   def width: Double
   def height: Double
   val sides = 4
-  override val perimeter = 2*width + 2*height
-  override val area = width*height
+  override def perimeter = 2*width + 2*height
+  override def area = width*height
 }
 
 case class Square(size: Double) extends Rectangular {


### PR DESCRIPTION
Exercise 4.1.4.3 Shaping Up 2 (Da Streets) had a bug.
Using the code as it existed meant that 

`new Square(2.0).perimeter`

was 0.0 (instead of 8.0)

This occurred because the `override val perimeter = 2 * ...` was evaluated at the definition of trait Rectangular, rather than after creation of a new Square object. The definition of `perimeter` and `area` should have used `def` or `lazy val`; the preceding text recommended using `def` within `traits`. Hence the change.